### PR TITLE
Add article API endpoints with validation and restricted methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::API
+  def method_not_allowed
+    render json: { error: "That method is not allowed on this endpoint." }, status: :method_not_allowed
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,2 +1,39 @@
 class ArticlesController < ApplicationController
+  def index
+    render json: Article.all.order(published_at: :desc)
+  end
+
+  def create
+    # Whitelist only the allowed parameters
+    permitted_params = params.permit(:title, :content, :author, :category, :published_at)
+  
+    # Create the article object
+    article = Article.new(permitted_params)
+
+    # Return the article and a 201 status if created successfully
+    if article.save
+      render json: article, status: :created
+    else
+      render json: { errors: article.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    # Making extra sure the id parameter is supplied
+    unless params[:id].present?
+      render json: {error: "No id given."}, status: :bad_request
+      return
+    end
+
+    # Find the article by id
+    article = Article.find_by(id: params[:id])
+
+    # If the article exists, return it. Otherwise, report the failure
+    if article
+      render json: article
+    else
+      render json: {error: 'Article not found.'}, status: :not_found
+    end
+  end
+
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,4 @@
 class Article < ApplicationRecord
+    validates :title, length: { maximum: 40 }
+    validates :content, :author, :category, :published_at, :title, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # Create the get, get by id, and post endpoints
+  resources :articles, only: [:index, :show, :create]
+
+  # 405 response to delete, put, and patch actions to /article/<id>
+  match '/articles/:id', to: 'application#method_not_allowed', via: [:put, :patch, :delete]
 end

--- a/db/migrate/20250603004227_create_articles.rb
+++ b/db/migrate/20250603004227_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :content
+      t.string :author
+      t.string :category
+      t.date :published_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2025_06_03_004227) do
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.string "author"
+    t.string "category"
+    t.date "published_at"
+  end
 
 end


### PR DESCRIPTION
### Description

This pull request implements the core features of the articles API as specified in the assignment:

- **GET /articles** - returns all articles sorted by `published_at` (most recent first)
- **GET /articles/:id** - returns a single article by its ID, with error handling for missing or invalid IDs
- **POST /articles** - creates a new article with all required fields and validations:
  - Title (max 40 characters)
  - Content, Author, Category, and Published Date (required)
- **PUT, PATCH, DELETE** requests to `/articles/:id` respond with HTTP `405 Method Not Allowed` to prevent unauthorized updates or deletions

### Additional Notes

- I used strong parameter filtering to guard against mass assignment vulnerabilities.
- Responses follow typical REST API standards with appropriate HTTP status codes and JSON responses.